### PR TITLE
chore(renovate): extend shared Python preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,5 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabled": true,
     "dependencyDashboard": false,
-    "extends": [
-        "config:recommended",
-        "github>jheddings/regula:python"
-    ]
+    "extends": ["config:recommended", "github>jheddings/regula:python"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,11 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabled": true,
     "dependencyDashboard": false,
-    "extends": ["config:base"],
-    "packageRules": [
-        {
-            "matchDepNames": ["python"],
-            "matchUpdateTypes": ["major", "minor"]
-        }
+    "extends": [
+        "config:recommended",
+        "github>jheddings/regula:python"
     ]
 }


### PR DESCRIPTION
Points Renovate at the shared Python preset in [regula](https://github.com/jheddings/regula).

The preset labels dev tooling (`pytest`, `ruff`, `pre-commit`, and similar) as `dep:ci` and automerges it, and holds back `python` runtime major and minor updates so those moves stay deliberate.

Also replaces `config:base`, which is deprecated, with `config:recommended`.

The local `packageRules` block is removed. It was expressing the python runtime hold, but had matchers and no settings:

```json
{ "matchDepNames": ["python"], "matchUpdateTypes": ["major", "minor"] }
```

Renovate matched those updates and then did nothing with them, so the rule never actually took effect here. It now comes from the shared preset, where it works.
